### PR TITLE
Updated README and portfolio-projects to include the merged past PR to the CloudRF API

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ I’m Ernest, a **Senior Systems Analyst** transitioning into **Cybersecurity an
 * **What:** Basic open-source contribution practices, collaborative version control skills.
 * **PR:** [Guestbook PR](https://github.com/OpenSource-Communities/guestbook/pull/705)
 
+### **CloudRF API Clients - Python 3 Migration**
+
+* **Objective:** Add compatibility for Cloud RF API clients using Python 3 while preserving Python 2 usage.
+* **What:** Refactored syntax/imports, split 2.x/3.x paths for compatibility; PR merged upstream (4 commits affecting ~20 files).
+* **PR:** [CloudRF #2 – Python changes](https://github.com/Cloud-RF/CloudRF-API-clients/pull/2)
+
+
 ---
 
 ## 🌟 Professional Background

--- a/portfolio-site/_data/projects.yml
+++ b/portfolio-site/_data/projects.yml
@@ -23,3 +23,9 @@
   duration: "February 2025"
   url: "https://github.com/open-sauced/guestbook/commit/21279d4b18ba27f653369fabf0befdd54195c6f8"
   description: "Open-source collaboration learning GitHub forking, branching, and PR submission workflow for basic open-source contribution practices, collaborative version control skills."
+
+- project: "CloudRF API Clients - Python 3 Migration"
+  role: "Contributor"
+  duration: "Dec 2018 - Feb 2019"
+  url: "https://github.com/Cloud-RF/CloudRF-API-clients/pull/2"
+  description: "Upgraded Python client code for CloudRF API: refactored for Python 3 compatibility and organized Python 2/3 variants; 4 commits merged across ~20 files (+345/−43)."

--- a/portfolio-site/_data/projects.yml
+++ b/portfolio-site/_data/projects.yml
@@ -26,6 +26,6 @@
 
 - project: "CloudRF API Clients - Python 3 Migration"
   role: "Contributor"
-  duration: "Dec 2018 - Feb 2019"
+  duration: "December 2018 - February 2019"
   url: "https://github.com/Cloud-RF/CloudRF-API-clients/pull/2"
   description: "Upgraded Python client code for CloudRF API: refactored for Python 3 compatibility and organized Python 2/3 variants; 4 commits merged across ~20 files (+345/−43)."


### PR DESCRIPTION
This pull request adds a new project entry to the portfolio and updates the README to document a contribution to the CloudRF API Clients project. The changes highlight the contributor's role in upgrading Python client code for Python 3 compatibility while maintaining support for Python 2.

Portfolio and documentation updates:

* Added a new project entry for "CloudRF API Clients - Python 3 Migration" in `portfolio-site/_data/projects.yml`, detailing the contributor's role, duration, link to the pull request, and a description of the work done (Python 3 compatibility refactor, 4 commits, ~20 files changed).
* Updated the `README.md` to include a summary of the CloudRF API Clients Python 3 migration project, outlining the objective, work performed, and a link to the merged pull request.